### PR TITLE
Follow Super+L, so the bar matches what Hyprland is tiling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -195,6 +195,13 @@ Established by probing 0.56.2; the Lua stubs are at `/usr/share/hypr/stubs/hl.me
 - A `FileView` watching a path that does not exist yet can emit neither
   `onLoaded` nor `onLoadFailed`, so `ConfigStore` has a fallback timer. Without
   it, a first run never becomes ready and nothing downstream ever runs.
+- **Omarchy's SUPER+L is a separate writer.** It persists
+  `~/.local/state/omarchy/workspace-layouts/<id>.lua` and applies a workspace
+  rule immediately. This plugin's generated file loads *after* those rules and
+  used to overwrite them with whatever the JSON last said. `OmarchyToggleFollow`
+  reads the directory (inotify + a startup `cat`) and writes Super+L's builtin
+  into the active profile. A live write always wins; the startup scan will not
+  steal a workspace that already has one of this plugin's layouts.
 
 **Editing a shipped layout forks it.** `Panel.forkPreset` runs inside the same
 `store.stage`/`store.mutate` as the edit, so the copy and the change land in one

--- a/Model.js
+++ b/Model.js
@@ -1234,6 +1234,58 @@ function layoutIdForWorkspace(config, workspaceId, monitorName) {
   return profile.fallback
 }
 
+// Omarchy's SUPER+L writes one Lua workspace rule per workspace under
+// ~/.local/state/omarchy/workspace-layouts. The plugin's own document is a
+// separate source of truth, so those files have to be read back in or Super+L
+// and this panel disagree the moment the key is pressed.
+function parseOmarchyToggleLua(text) {
+  var matches = parseOmarchyToggleFiles(text)
+  return matches.length > 0 ? matches[0] : null
+}
+
+function parseOmarchyToggleFiles(text) {
+  var source = String(text || "")
+  var re = /workspace\s*=\s*"(\d+)"\s*,\s*layout\s*=\s*"([^"]+)"/g
+  var out = []
+  var match
+  while ((match = re.exec(source)) !== null) {
+    var workspace = normalizeWorkspaceId(match[1])
+    var layout = String(match[2] || "")
+    if (workspace === null || !isBuiltin(layout)) continue
+    out.push({ workspace: workspace, layout: layout })
+  }
+  return out
+}
+
+// Write Super+L's choice into the active profile. Returns a new document when
+// something actually changed, or null when the plugin already agrees — callers
+// persist only on a real change, so a file watcher cannot loop.
+//
+// `onlyBuiltins` is the startup scan: a leftover Super+L file must not steal a
+// workspace the user later gave to one of this plugin's layouts. A live write
+// (the key just pressed) is an explicit choice and always wins.
+function followOmarchyToggles(config, assignments, opts) {
+  var options = opts || {}
+  var normalized = normalizeConfig(config)
+  var list = assignments instanceof Array ? assignments : []
+  var draft = null
+  var profile = null
+  for (var i = 0; i < list.length; i++) {
+    var workspace = normalizeWorkspaceId(list[i] && list[i].workspace)
+    var layout = String((list[i] && list[i].layout) || "")
+    if (workspace === null || !isBuiltin(layout)) continue
+    var current = layoutIdForWorkspace(draft || normalized, workspace)
+    if (current === layout) continue
+    if (options.onlyBuiltins && !isBuiltin(current)) continue
+    if (!draft) {
+      draft = JSON.parse(JSON.stringify(normalized))
+      profile = activeProfile(draft)
+    }
+    profile.assignments[workspace] = layout
+  }
+  return draft
+}
+
 // The pins in the active profile, as a sorted list, so the generated file is
 // stable across edits that only reorder the JSON.
 function pinEntries(config) {
@@ -2774,6 +2826,9 @@ if (typeof module !== "undefined") {
     findProfile: findProfile,
     activeProfile: activeProfile,
     layoutIdForWorkspace: layoutIdForWorkspace,
+    parseOmarchyToggleLua: parseOmarchyToggleLua,
+    parseOmarchyToggleFiles: parseOmarchyToggleFiles,
+    followOmarchyToggles: followOmarchyToggles,
     normalizeAppMatch: normalizeAppMatch,
     normalizePin: normalizePin,
     slotKeys: slotKeys,

--- a/OmarchyToggleFollow.qml
+++ b/OmarchyToggleFollow.qml
@@ -1,0 +1,106 @@
+import QtQuick
+import Quickshell
+import Quickshell.Io
+import "Model.js" as Model
+
+// Keeps this plugin's document in step with Omarchy's SUPER+L toggle.
+//
+// SUPER+L writes ~/.local/state/omarchy/workspace-layouts/<id>.lua and applies
+// the rule immediately. This plugin used to ignore those files, so the bar
+// stayed on dwindle after Hyprland had already moved — and the next sync
+// wrote dwindle back over the toggle. Watching the directory and adopting
+// builtins is what makes the two agree.
+Item {
+  id: root
+
+  property var config: null
+  property bool active: true
+
+  // First scan is a catch-up for files already on disk. A leftover Super+L
+  // file must not steal a workspace later given to one of this plugin's
+  // layouts; a write that arrives afterwards is the key just pressed.
+  property bool startupImport: true
+
+  signal followed(var document)
+
+  readonly property string home: Quickshell.env("HOME")
+  readonly property string stateHome: Quickshell.env("XDG_STATE_HOME") || (home + "/.local/state")
+  readonly property string dir: stateHome + "/omarchy/workspace-layouts"
+
+  function ingest(text, onlyBuiltins) {
+    if (!root.active || !root.config) return
+    var assignments = Model.parseOmarchyToggleFiles(text)
+    var next = Model.followOmarchyToggles(root.config, assignments, { onlyBuiltins: onlyBuiltins })
+    if (next) root.followed(next)
+  }
+
+  function scan() {
+    if (!root.active) return
+    if (!scanProcess.running) scanProcess.running = true
+  }
+
+  // mkdir and the JSON load race: if the first scan ran while the store was
+  // still empty it returned without reading, and nothing else would try again.
+  onActiveChanged: if (root.active) scanTimer.restart()
+
+  Process {
+    id: ensureDir
+    running: true
+    command: ["mkdir", "-p", root.dir]
+    onExited: function() {
+      dirWatch.reload()
+      watchProcess.running = true
+      scanTimer.restart()
+    }
+  }
+
+  FileView {
+    id: dirWatch
+    path: root.dir
+    watchChanges: true
+    printErrors: false
+    onFileChanged: scanTimer.restart()
+  }
+
+  // close_write is Super+L overwriting an existing file; create is the first
+  // toggle on a workspace that had no file yet. FileView on the directory
+  // catches structure changes, this catches the overwrite.
+  Process {
+    id: watchProcess
+    command: ["inotifywait", "-m", "-q",
+      "-e", "close_write", "-e", "create", "-e", "moved_to",
+      "--format", "%f", root.dir]
+    stdout: SplitParser {
+      onRead: function(line) { scanTimer.restart() }
+    }
+    onExited: function() { pollTimer.running = true }
+  }
+
+  Process {
+    id: scanProcess
+    command: ["sh", "-c", "cat -- \"" + root.dir + "\"/*.lua 2>/dev/null"]
+    stdout: StdioCollector {
+      waitForEnd: true
+      onStreamFinished: {
+        var onlyBuiltins = root.startupImport
+        root.startupImport = false
+        root.ingest(String(text || ""), onlyBuiltins)
+      }
+    }
+  }
+
+  Timer {
+    id: scanTimer
+    interval: 80
+    repeat: false
+    onTriggered: root.scan()
+  }
+
+  Timer {
+    id: pollTimer
+    interval: 800
+    repeat: true
+    running: false
+    onTriggered: scanTimer.restart()
+  }
+}

--- a/Panel.qml
+++ b/Panel.qml
@@ -1304,6 +1304,12 @@ Panel {
     onRevisionChanged: syncTimer.restart()
   }
 
+  OmarchyToggleFollow {
+    config: store.config
+    active: store.ready
+    onFollowed: function(document) { store.save(document) }
+  }
+
   HyprlandSync {
     id: sync
     config: store.config

--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ A list of everything it does is in [docs/features.md](docs/features.md).
 ## Using it
 
 Click the bar icon — it is a live miniature of the current workspace's layout.
+Omarchy's `Super + L` dwindle/scrolling toggle is followed, so the picture
+matches the workspace Hyprland is actually tiling.
 The panel scrolls when it outgrows the screen, and `Esc` closes it — everything
 else in it is pointed at rather than typed.
 

--- a/Service.qml
+++ b/Service.qml
@@ -44,6 +44,12 @@ Item {
     onRevisionChanged: syncTimer.restart()
   }
 
+  OmarchyToggleFollow {
+    config: store.config
+    active: store.ready
+    onFollowed: function(document) { store.save(document) }
+  }
+
   HyprlandSync {
     id: sync
     config: store.config

--- a/docs/features.md
+++ b/docs/features.md
@@ -47,6 +47,8 @@ Everything the plugin does, in one list.
 - The tile you are carrying follows the cursor with its name and target
 - The bar icon is a live miniature of the layout the focused workspace is
   running
+- Omarchy's Super+L dwindle/scrolling toggle is followed, so the bar and the
+  panel match the workspace Hyprland is actually tiling
 - Clicking a workspace takes you to it
 - The panel scrolls when it grows taller than the screen
 - Restore defaults puts back the shipped layouts, one profile, and every

--- a/tests/model.test.js
+++ b/tests/model.test.js
@@ -1865,6 +1865,67 @@ test("slot lists arrive from a shell in whatever shape the shell felt like", () 
   assert.deepEqual(Model.parseSlots(null), [])
 })
 
+// ------------------------------------------------ Super+L / Omarchy toggle
+//
+// Omarchy's SUPER+L writes one Lua workspace rule per workspace under
+// ~/.local/state/omarchy/workspace-layouts. The plugin used to ignore those
+// files, so the bar stayed on dwindle after the compositor had already moved.
+
+test("Omarchy's Super+L rule files parse into workspace layout pairs", () => {
+  const text = [
+    'hl.workspace_rule({ workspace = "6", layout = "scrolling" })',
+    'hl.workspace_rule({ workspace = "1", layout = "dwindle" })',
+    'hl.workspace_rule({ workspace = "9", layout = "lua:omarchy-wsl-focus" })',
+    "garbage"
+  ].join("\n")
+  assert.deepEqual(Model.parseOmarchyToggleFiles(text), [
+    { workspace: "6", layout: "scrolling" },
+    { workspace: "1", layout: "dwindle" }
+  ])
+  assert.deepEqual(Model.parseOmarchyToggleFiles(""), [])
+  assert.deepEqual(Model.parseOmarchyToggleLua(
+    'hl.workspace_rule({ workspace = "2", layout = "master" })'
+  ), { workspace: "2", layout: "master" })
+  assert.equal(Model.parseOmarchyToggleLua("not a rule"), null)
+})
+
+test("Super+L scrolling is written into the active profile", () => {
+  const config = Model.normalizeConfig({
+    profiles: [{ name: "default", fallback: "dwindle", assignments: { 6: "dwindle" } }]
+  })
+  const next = Model.followOmarchyToggles(config, [{ workspace: 6, layout: "scrolling" }])
+  assert.equal(Model.layoutIdForWorkspace(next, 6), "scrolling")
+  assert.equal(next.profiles[0].assignments["6"], "scrolling")
+  assert.match(Model.generateLua(next, [6]), /W\.set_workspace\("6", "scrolling"\)/)
+})
+
+test("a Super+L file that already matches is a no-op", () => {
+  const config = Model.normalizeConfig({
+    profiles: [{ name: "default", fallback: "dwindle", assignments: { 6: "scrolling" } }]
+  })
+  assert.equal(Model.followOmarchyToggles(config, [{ workspace: 6, layout: "scrolling" }]), null)
+})
+
+test("startup import does not steal a custom layout from a stale Super+L file", () => {
+  const config = Model.normalizeConfig({
+    layouts: [{ id: "focus", name: "Focus", weights: [25, 50, 25] }],
+    profiles: [{ name: "default", fallback: "dwindle", assignments: { 6: "focus" } }]
+  })
+  assert.equal(
+    Model.followOmarchyToggles(config, [{ workspace: 6, layout: "scrolling" }], { onlyBuiltins: true }),
+    null
+  )
+  const live = Model.followOmarchyToggles(config, [{ workspace: 6, layout: "scrolling" }])
+  assert.equal(Model.layoutIdForWorkspace(live, 6), "scrolling")
+})
+
+test("the panel and the service follow Omarchy's Super+L files", () => {
+  const panel = fs.readFileSync(path.join(__dirname, "..", "Panel.qml"), "utf8")
+  const service = fs.readFileSync(path.join(__dirname, "..", "Service.qml"), "utf8")
+  assert.match(panel, /OmarchyToggleFollow/)
+  assert.match(service, /OmarchyToggleFollow/)
+})
+
 // ----------------------------------------------------------------- loader
 
 test("the Hyprland loader line is added once and only once", () => {


### PR DESCRIPTION
Omarchy's `Super + L` writes a Lua workspace rule under `~/.local/state/omarchy/workspace-layouts` and applies it immediately. This plugin ignored those files, so the bar stayed on dwindle after Hyprland had already moved — and the next sync wrote dwindle back over the toggle.

The files are now read back into the active profile:

- A live write is the key just pressed and always wins.
- A leftover file at startup will not steal a workspace that already has one of this plugin's layouts.

Verified by running `omarchy-hyprland-workspace-layout-toggle` on workspace 6: Hyprland and `omarchy-shell workspace-layout workspace 6` both moved dwindle → scrolling → dwindle together.

`node --test tests/model.test.js` and `omarchy plugin validate .` pass.